### PR TITLE
Added dns_arpanize filter

### DIFF
--- a/sara_cmt/cmt_server/cmt_server/apps/cluster/templatetags/dns_extras.py
+++ b/sara_cmt/cmt_server/cmt_server/apps/cluster/templatetags/dns_extras.py
@@ -1,0 +1,30 @@
+from IPy import IP
+
+import re
+
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+@register.filter
+@stringfilter
+def dns_arpanize(value):
+    ip = IP(value)
+
+    # Well the maker of IPy has his own way for arpanize which is not widely used
+    #  <network>-<broadcast.<subnet> must be:
+    #  <broadcast>-<network>.<subnet>
+    reverse_name = ip.reverseName()
+
+    # When it's a classless reverse do some extra magic
+    if re.search(r'[0-9]+\-[0-9]+\.[0-9\.]+', reverse_name):
+        parts = reverse_name.split('.')
+
+        reverse_name = "-".join(parts[0].split('-')[::-1]) + "." + ".".join(parts[1:])
+    # When there is a leading 0. remove it for a clean arpanize
+    elif re.search(r'0\.[0-9\.]+', reverse_name):
+        reverse_name = ".".join(reverse_name.split('.')[1:])
+
+    # Remove the last dot
+    return reverse_name.rstrip('.')

--- a/sara_cmt/cmt_server/cmt_server/apps/cluster/templatetags/dns_extras.py
+++ b/sara_cmt/cmt_server/cmt_server/apps/cluster/templatetags/dns_extras.py
@@ -12,6 +12,10 @@ register = template.Library()
 def dns_arpanize(value):
     ip = IP(value)
 
+    # When it's ipv6 just return the reverseName
+    if ip.version == 6:
+        return ip.reverseName()
+
     # Well the maker of IPy has his own way for arpanize which is not widely used
     #  <network>-<broadcast.<subnet> must be:
     #  <broadcast>-<network>.<subnet>


### PR DESCRIPTION
Created a new filter called dns_arpanize. This has been created to replace the current arpanize function which is limited in use. The dns_arpanize function utilizes the IPy module for reversing.

You can also reverse subnets to classless reverse arpa names. Also ipv6 is supported. To remain compatible with the current written templates i have added this filter to a new templatetags file called dns_extras.py. You can load this template by using `{% load 'dns_extras' %}`.
